### PR TITLE
Fix Angular 20 dev-server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Due to environment limitations there is no generated build or installed dependen
 - `src/product-list.component.ts` – lists products using the `@for` control flow.
 - `src/product.service.ts` – provides products via an Angular signal.
 - `angular.json` – minimal Angular CLI workspace configuration.
+- `serve.options.buildTarget` in `angular.json` links the dev server to the build
+  target.
 - `tsconfig.json` – base TypeScript configuration targeting ES2022.
 - `tsconfig.app.json` – application-specific TypeScript settings.
 - `src/index.html` – host page used by Angular CLI.

--- a/angular.json
+++ b/angular.json
@@ -23,7 +23,7 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "online-store:build"
+            "buildTarget": "online-store:build"
           }
         }
       }


### PR DESCRIPTION
## Summary
- use `buildTarget` instead of `browserTarget` in `angular.json`
- document the new `buildTarget` property in README

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852d5a5a9248331b1e99cb1dff73fbc