### PR TITLE
Add master/detail pages for products

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,9 +1,13 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
-import { provideRouter } from '@angular/router';
+import { provideRouter, withComponentInputBinding } from '@angular/router';
 
 import { routes } from './app.routes';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes), provideClientHydration(withEventReplay())]
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(routes, withComponentInputBinding()),
+    provideClientHydration(withEventReplay()),
+  ],
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,7 +1,9 @@
 import { Routes } from '@angular/router';
 import { ProductListComponent } from './product/product-list.component';
+import { ProductDetailComponent } from './product/product-detail.component';
 
 export const routes: Routes = [
   { path: '', redirectTo: '/products', pathMatch: 'full' },
   { path: 'products', loadComponent: () => ProductListComponent },
+  { path: 'products/:id', loadComponent: () => ProductDetailComponent },
 ];

--- a/src/app/product/product-detail.component.ts
+++ b/src/app/product/product-detail.component.ts
@@ -1,0 +1,26 @@
+import { Component, Input, OnChanges } from '@angular/core';
+import { ProductService } from './product.service';
+import { Product } from './product';
+
+@Component({
+  selector: 'product-detail',
+  standalone: true,
+  template: `
+    @if (product as p) {
+      <h2>{{ p.name }}</h2>
+      <p>Price: {{ p.price }}</p>
+    } @else {
+      <p>Product not found</p>
+    }
+  `,
+})
+export class ProductDetailComponent implements OnChanges {
+  @Input() id!: number;
+  product?: Product;
+
+  constructor(private service: ProductService) {}
+
+  ngOnChanges() {
+    this.product = this.service.getProductById(Number(this.id));
+  }
+}

--- a/src/app/product/product-list.component.ts
+++ b/src/app/product/product-list.component.ts
@@ -1,12 +1,11 @@
 import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { ProductService } from './product.service';
 
 @Component({
   selector: 'product-list',
   standalone: true,
-  imports: [CommonModule, RouterLink],
+  imports: [RouterLink],
   template: `
     <h2>Products</h2>
     <ul>

--- a/src/app/product/product.service.ts
+++ b/src/app/product/product.service.ts
@@ -9,4 +9,8 @@ export class ProductService {
   ]);
 
   products = this.productsSignal.asReadonly();
+
+  getProductById(id: number): Product | undefined {
+    return this.productsSignal().find((p) => p.id === id);
+  }
 }


### PR DESCRIPTION
## Summary
- create `ProductDetailComponent` for viewing individual products
- add lookup helper in `ProductService`
- add route for product details
- use new Angular control flow and route input binding
- enable global component input binding
- remove redundant CommonModule imports

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853ba271ed0833180c0bb198eb5bb6b