### PR TITLE
Extend product model and update views

### DIFF
--- a/src/app/product/product-detail.component.ts
+++ b/src/app/product/product-detail.component.ts
@@ -1,26 +1,31 @@
-import { Component, Input, OnChanges } from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, inject, input } from '@angular/core';
+import { NgOptimizedImage } from '@angular/common';
 import { ProductService } from './product.service';
-import { Product } from './product';
 
 @Component({
   selector: 'product-detail',
-  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgOptimizedImage],
   template: `
-    @if (product; as p) {
+    @if (product(); as p) {
       <h2>{{ p.name }}</h2>
+      <img
+        [ngSrc]="p.imageUrl"
+        alt="{{ p.name }}"
+        width="200"
+        height="200"
+      />
       <p>Price: {{ p.price }}</p>
+      <p>Rating: {{ p.rate }}</p>
+      <p>Tags: {{ p.tags.join(', ') }}</p>
+      <p>{{ p.description }}</p>
     } @else {
       <p>Product not found</p>
     }
   `,
 })
-export class ProductDetailComponent implements OnChanges {
-  @Input() id!: number;
-  product?: Product;
-
-  constructor(private service: ProductService) {}
-
-  ngOnChanges() {
-    this.product = this.service.getProductById(Number(this.id));
-  }
+export class ProductDetailComponent {
+  id = input<number>();
+  private service = inject(ProductService);
+  product = computed(() => this.service.getProductById(Number(this.id())));
 }

--- a/src/app/product/product-list.component.ts
+++ b/src/app/product/product-list.component.ts
@@ -1,24 +1,32 @@
-import { Component } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { NgOptimizedImage } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { ProductService } from './product.service';
 
 @Component({
   selector: 'product-list',
-  standalone: true,
-  imports: [RouterLink],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [RouterLink, NgOptimizedImage],
   template: `
     <h2>Products</h2>
     <ul>
       @for (product of products(); track product.id) {
         <li>
-          <a [routerLink]="['/products', product.id]">{{ product.name }}</a>
+          <a [routerLink]="['/products', product.id]">
+            <img
+              [ngSrc]="product.imageUrl"
+              alt="{{ product.name }}"
+              width="50"
+              height="50"
+            />
+            {{ product.name }}
+          </a>
         </li>
       }
     </ul>
   `,
 })
 export class ProductListComponent {
+  private service = inject(ProductService);
   products = this.service.products;
-
-  constructor(private service: ProductService) {}
 }

--- a/src/app/product/product.service.ts
+++ b/src/app/product/product.service.ts
@@ -4,8 +4,24 @@ import { Product } from './product';
 @Injectable({ providedIn: 'root' })
 export class ProductService {
   private productsSignal = signal<Product[]>([
-    { id: 1, name: 'Item A', price: 10 },
-    { id: 2, name: 'Item B', price: 20 },
+    {
+      id: 1,
+      name: 'Item A',
+      price: 10,
+      imageUrl: 'https://picsum.photos/seed/product-1/200/200',
+      rate: 4,
+      tags: ['popular', 'new'],
+      description: 'A great item for everyday use.',
+    },
+    {
+      id: 2,
+      name: 'Item B',
+      price: 20,
+      imageUrl: 'https://picsum.photos/seed/product-2/200/200',
+      rate: 5,
+      tags: ['sale'],
+      description: 'An even better item with premium features.',
+    },
   ]);
 
   products = this.productsSignal.asReadonly();

--- a/src/app/product/product.ts
+++ b/src/app/product/product.ts
@@ -2,4 +2,8 @@ export interface Product {
   id: number;
   name: string;
   price: number;
+  imageUrl: string;
+  rate: number;
+  tags: string[];
+  description: string;
 }


### PR DESCRIPTION
## Summary
- expand product fields with image URL, rating, tags and description
- update service to provide data for the new fields using picsum.photos
- display product images in the list and detail views
- remove local sample images

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853c5721c8c8331ace849c3576238fe