### PR TITLE
Improve sidenav styling and layout

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -11,22 +11,27 @@ html, body {
 
 mat-sidenav {
   width: 200px;
+  background-color: var(--md-sys-color-surface-container-high);
+  color: var(--md-sys-color-on-surface);
 }
 
 mat-sidenav-content {
   display: flex;
   flex-direction: column;
   height: 100%;
+  overflow: hidden;
 }
 
 .content {
   padding: 16px;
   flex: 1 1 auto;
+  overflow-y: auto;
 }
 
 .app-footer {
   text-align: center;
   padding: 8px;
+  margin-top: auto;
 }
 
 // Include core styles for Angular Material


### PR DESCRIPTION
## Summary
- darken sidenav background with Material theme token
- keep footer at the bottom and prevent window scroll
- allow scrolling only within main content

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853cc5697e88331ab6297fd88eb25fc