### PR TITLE
Fix skeleton placeholders

### DIFF
--- a/src/app/product/product.service.ts
+++ b/src/app/product/product.service.ts
@@ -45,6 +45,10 @@ export class ProductService {
     this.loading.set(false);
   }
 
+  remaining(): number {
+    return this.all.length - this.index;
+  }
+
   getProductById(id: number): Product | undefined {
     return this.all.find((p) => p.id === id);
   }


### PR DESCRIPTION
## Summary
- show placeholders for each product while loading
- compute placeholder count based on remaining items

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_685410ade9d4833199a6967446866586