### PR TITLE
Fix pagination in virtual scroll grid

### DIFF
--- a/src/app/product/product-row-data-source.ts
+++ b/src/app/product/product-row-data-source.ts
@@ -18,7 +18,17 @@ export class ProductRowDataSource extends DataSource<(Product | undefined)[]> {
   private readonly perRow = 4;
 
   connect(viewer: CollectionViewer): Observable<(Product | undefined)[][]> {
-    return this.base.connect(viewer).pipe(map((items) => chunkArray(items, this.perRow)));
+    const adaptedViewer: CollectionViewer = {
+      viewChange: viewer.viewChange.pipe(
+        map((range) => ({
+          start: range.start * this.perRow,
+          end: range.end * this.perRow,
+        }))
+      ),
+    };
+    return this.base
+      .connect(adaptedViewer)
+      .pipe(map((items) => chunkArray(items, this.perRow)));
   }
 
   disconnect(): void {


### PR DESCRIPTION
## Summary
- handle row indices correctly when fetching new pages

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68546251070483319c9504a389e8f26a