### PR TITLE
Setup Jest and add service tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ This will compile your project and store the build artifacts in the `dist/` dire
 
 ## Running unit tests
 
-To execute unit tests with the [Karma](https://karma-runner.github.io) test runner, use the following command:
+Unit tests run with [Jest](https://jestjs.io). Execute them with:
 
 ```bash
-ng test
+pnpm test
 ```
 
 ## Running end-to-end tests

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  extensionsToTreatAsEsm: ['.ts'],
+  setupFilesAfterEnv: ["<rootDir>/setup-jest.ts"],
+  moduleNameMapper: {
+    '^(\.{1,2}/.*)\.js$': '$1',
+  },
+  testMatch: ['<rootDir>/src/**/*.spec.ts'],
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test",
+    "test": "jest",
     "serve:ssr:online-store": "node dist/online-store/server/server.mjs"
   },
   "private": true,
@@ -33,14 +33,11 @@
     "@angular/cli": "^19.2.5",
     "@angular/compiler-cli": "^19.2.0",
     "@types/express": "^4.17.17",
-    "@types/jasmine": "~5.1.0",
+    "@types/jest": "^29.5.3",
     "@types/node": "^18.18.0",
-    "jasmine-core": "~5.6.0",
-    "karma": "~6.4.0",
-    "karma-chrome-launcher": "~3.2.0",
-    "karma-coverage": "~2.2.0",
-    "karma-jasmine": "~5.1.0",
-    "karma-jasmine-html-reporter": "~2.1.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "typescript": "~5.7.2"
   }
 }

--- a/setup-jest.ts
+++ b/setup-jest.ts
@@ -1,0 +1,12 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);
+

--- a/src/app/product/product-data-source.spec.ts
+++ b/src/app/product/product-data-source.spec.ts
@@ -1,0 +1,23 @@
+import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject, of } from 'rxjs';
+import { CollectionViewer } from '@angular/cdk/collections';
+import { ProductDataSource } from './product-data-source';
+import { ProductService } from './product.service';
+
+describe('ProductDataSource', () => {
+  it('calls fetch on view range', async () => {
+    const fetch = jest.fn().mockResolvedValue([]);
+    const service = { loadSize: 20, total: 40, fetch } as ProductService;
+    TestBed.configureTestingModule({ providers: [
+      { provide: ProductService, useValue: service },
+      ProductDataSource,
+    ]});
+
+    const dataSource = TestBed.inject(ProductDataSource);
+    const viewChange = new BehaviorSubject<{start: number; end: number}>({start:0,end:20});
+    const viewer: CollectionViewer = { viewChange };
+    dataSource.connect(viewer).subscribe();
+    await Promise.resolve();
+    expect(fetch).toHaveBeenCalledWith(0, 20);
+  });
+});

--- a/src/app/product/product-row-data-source.spec.ts
+++ b/src/app/product/product-row-data-source.spec.ts
@@ -1,0 +1,25 @@
+import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject, of } from 'rxjs';
+import { CollectionViewer } from '@angular/cdk/collections';
+import { ProductRowDataSource } from './product-row-data-source';
+import { ProductDataSource } from './product-data-source';
+import { Product } from './product';
+
+describe('ProductRowDataSource', () => {
+  it('groups products into rows of four', async () => {
+    const products: (Product | undefined)[] = Array.from({ length: 5 }, (_, i) => ({ id: i + 1 } as Product));
+    const connect = jest.fn().mockReturnValue(of(products));
+    const base = { connect, disconnect: jest.fn() } as unknown as ProductDataSource;
+
+    TestBed.configureTestingModule({ providers: [
+      { provide: ProductDataSource, useValue: base },
+      ProductRowDataSource,
+    ]});
+
+    const dataSource = TestBed.inject(ProductRowDataSource);
+    const viewChange = new BehaviorSubject<{start:number; end:number}>({start:0,end:1});
+    const viewer: CollectionViewer = { viewChange };
+    const result = await dataSource.connect(viewer).toPromise();
+    expect(result).toEqual([[{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }], [{ id: 5 }]]);
+  });
+});

--- a/src/app/product/product.service.spec.ts
+++ b/src/app/product/product.service.spec.ts
@@ -1,0 +1,17 @@
+import { ProductService } from './product.service';
+
+describe('ProductService', () => {
+  it('fetch returns a slice of products', async () => {
+    const service = new ProductService();
+    const items = await service.fetch(0, 3);
+    expect(items).toHaveLength(3);
+    expect(items[0].id).toBe(1);
+    expect(items[2].id).toBe(3);
+  });
+
+  it('getProductById returns the correct product', () => {
+    const service = new ProductService();
+    const product = service.getProductById(5);
+    expect(product?.id).toBe(5);
+  });
+});

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -5,8 +5,9 @@
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
     "types": [
-      "jasmine"
-    ]
+      "jest"
+    ],
+    "module": "CommonJS"
   },
   "include": [
     "src/**/*.spec.ts",


### PR DESCRIPTION
## Summary
- configure Jest and add setup file
- add unit tests for service and data sources
- update TypeScript config for Jest
- document running tests

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685481e318f4833187b1a780c8886b2e