### PR TITLE
Add integration specs with Angular Testing Library

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "typescript": "~5.7.2"
+    "typescript": "~5.7.2",
+    "@testing-library/angular": "^14.1.1",
+    "@testing-library/jasmine-dom": "^1.2.2"
   }
 }

--- a/src/app/product/product-detail.component.spec.ts
+++ b/src/app/product/product-detail.component.spec.ts
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/angular';
+import { ProductDetailComponent } from './product-detail.component';
+
+describe('ProductDetailComponent', () => {
+  it('should show product detail for given id', async () => {
+    await render(ProductDetailComponent, {
+      componentInputs: { id: 1 },
+    });
+
+    expect(await screen.findByText('Product 1')).toBeTruthy();
+    expect(await screen.findByText('$ 1')).toBeTruthy();
+  });
+});

--- a/src/app/product/product-list.component.spec.ts
+++ b/src/app/product/product-list.component.spec.ts
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/angular';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ProductListComponent } from './product-list.component';
+
+describe('ProductListComponent', () => {
+  it('should display the first product after load', async () => {
+    await render(ProductListComponent, {
+      imports: [RouterTestingModule],
+    });
+
+    expect(await screen.findByText('Product 1')).toBeTruthy();
+  });
+});

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,22 @@
+import 'zone.js/testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+import '@testing-library/jasmine-dom';
+
+declare const require: {
+  context(path: string, deep?: boolean, filter?: RegExp): {
+    keys(): string[];
+    <T>(id: string): T;
+  };
+};
+
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting(),
+);
+
+const context = require.context('./', true, /\.spec\.ts$/);
+context.keys().forEach(context);


### PR DESCRIPTION
## Summary
- configure Testing Library in the project
- add integration tests for product list and detail components

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6854826aec5083319087fde8b5ed0799