### PR TITLE
Fix zone initialization for Jest

### DIFF
--- a/setup-jest.ts
+++ b/setup-jest.ts
@@ -1,3 +1,5 @@
+// Ensure Zone.js is loaded before configuring Angular's testing environment
+import 'zone.js';
 import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -7,7 +7,7 @@
     "types": [
       "jest"
     ],
-    "module": "CommonJS"
+    "module": "ESNext"
   },
   "include": [
     "src/**/*.spec.ts",


### PR DESCRIPTION
## Summary
- ensure Zone.js is loaded when running tests
- compile unit tests as ES modules

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68548f4231508331bfceb525ea46bf7b