### PR TITLE
Fix jest ESM configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "online-store",
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
## Summary
- enable ESM support so Jest can parse ES modules

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_685510c2e7988331932d16fd5060ce27